### PR TITLE
fix: remove misleading comment about lowercase fortran (closes #26)

### DIFF
--- a/src/frontend/frontend.f90
+++ b/src/frontend/frontend.f90
@@ -104,7 +104,7 @@ contains
         if (error_msg /= "") return
         if (options%debug_ast) call debug_output_ast(input_file, arena, prog_index)
 
-        ! Phase 3: Semantic Analysis (only for lowercase fortran)
+        ! Phase 3: Semantic Analysis (runs unconditionally)
         ! Use the version with INTENT checking
         call analyze_program_with_checks(arena, prog_index)
    if (options%debug_semantic) call debug_output_semantic(input_file, arena, prog_index)
@@ -147,7 +147,7 @@ contains
         if (error_msg /= "") return
        if (options%debug_ast) call debug_output_ast(tokens_json_file, arena, prog_index)
 
-        ! Phase 3: Semantic Analysis (only for lowercase fortran)
+        ! Phase 3: Semantic Analysis (runs unconditionally)
         ! Use the version with INTENT checking
         call analyze_program_with_checks(arena, prog_index)
         if (options%debug_semantic) call debug_output_semantic(tokens_json_file, arena, prog_index)


### PR DESCRIPTION
Removed misleading comment in src/frontend/frontend.f90 as per #26